### PR TITLE
Add GPU-accelerated payoff computation

### DIFF
--- a/GPU程序调试/PGG_A.py
+++ b/GPU程序调试/PGG_A.py
@@ -24,7 +24,14 @@ import logging
 import time
 from collections import Counter
 
-from gaming_models import calc_C_num, calc_profit_PGG, game_stra_learn, game_stra_learn_withPrefer
+from gaming_models import (
+    calc_C_num,
+    calc_profit_PGG,
+    game_stra_learn,
+    game_stra_learn_withPrefer,
+    get_accelerator_device_name,
+    is_gpu_enabled,
+)
 
 from net_creat import  creat_Net
 
@@ -634,10 +641,22 @@ def main_single_net(netType_i, DynamicNum_arr, del_way_i, inc_stra_i, KP_i, k_i,
 if __name__ == '__main__':
          
     multiprocessing.freeze_support()
-         
+
     date_time_1 = datetime.datetime.now()
     print("Gaming Started at " + str(date_time_1) + "!!\n")
-   
+
+    if is_gpu_enabled():
+        gpu_message = (
+            "GPU加速已启用，收益计算将在 "
+            + get_accelerator_device_name()
+            + " 上运行。"
+        )
+    else:
+        gpu_message = "GPU加速不可用，将使用CPU版本的收益计算。"
+
+    print(gpu_message + "\n")
+    logging.info(gpu_message)
+
     sizes = [100]    # 30, 60, 30
     r_range = [1, 5, 0.1]
     alpha_range = [0, 0.5, 0.01]

--- a/GPU程序调试/程序及GPU情况说明.txt
+++ b/GPU程序调试/程序及GPU情况说明.txt
@@ -6,3 +6,10 @@ realnets目录下为真实网络数据集
 
 现有GPU配置为一台机器配英伟达T1000 8GB，一台配英伟达A2000 12GB
 
+2024年8月GPU加速更新：
+1. gaming_models.calc_profit_PGG 新增基于 PyTorch 的 GPU 版本，检测到可用的 CUDA 设备时自动启用。
+2. 运行开始时主程序会在控制台与日志中输出是否启用了 GPU 加速及所使用的设备。
+3. 支持环境变量控制：设置 `PGG_FORCE_CPU=1` 可强制退回 CPU，`PGG_GPU_DEVICE` 可指定 CUDA 设备（默认 `cuda`）。
+4. 提供 `gaming_models.is_gpu_enabled()` 与 `gaming_models.get_accelerator_device_name()` 接口供脚本内查询；调用 `gaming_models.set_gpu_mode(True/False)` 可手动切换。
+5. 若当前环境未安装 PyTorch 或缺少 GPU，程序会自动降级到原有的 CPU 实现，保持兼容性。
+


### PR DESCRIPTION
## Summary
- add a PyTorch-backed GPU payoff computation for the Public Goods Game with automatic CUDA detection and manual controls
- log and display the active device when starting simulations and update the GPU usage documentation

## Testing
- python -m compileall gaming_models.py PGG_A.py

------
https://chatgpt.com/codex/tasks/task_e_68d10b857ad88332964c75a83e9faa7b