### PR TITLE
Fix dataclass slots initialization for RNG and accelerator

### DIFF
--- a/GPU程序调试/pgg_gaming/network.py
+++ b/GPU程序调试/pgg_gaming/network.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import math
 import random
 from typing import Iterable, List
@@ -17,6 +17,7 @@ class NetworkFactory:
     """根据配置生成不同拓扑类型的网络。"""
 
     seed: int | None = None
+    _random: random.Random = field(init=False, repr=False)
 
     def __post_init__(self) -> None:  # 初始化随机数发生器
         self._random = random.Random(self.seed)

--- a/GPU程序调试/pgg_gaming/payoff.py
+++ b/GPU程序调试/pgg_gaming/payoff.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 from typing import Iterable, List
 
@@ -25,6 +25,7 @@ class PublicGoodsPayoffCalculator:
 
     investment: float = 1.0
     accelerator: AcceleratorController | None = None
+    _accelerator: AcceleratorController = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._accelerator = self.accelerator or AcceleratorController()

--- a/GPU程序调试/pgg_gaming/strategy.py
+++ b/GPU程序调试/pgg_gaming/strategy.py
@@ -16,6 +16,7 @@ class StrategyInitializer:
 
     cooperative_probability: float = 0.5
     seed: int | None = None
+    _rng: random.Random = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._rng = random.Random(self.seed)
@@ -35,6 +36,7 @@ class StrategyUpdater:
 
     temperature: float = 0.5
     seed: int | None = None
+    _rng: random.Random = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._rng = random.Random(self.seed)


### PR DESCRIPTION
## Summary
- declare cached accelerator and random number generator attributes on dataclasses that use slots
- prevent AttributeError during simulator start-up by ensuring __post_init__ assignments target defined fields

## Testing
- python GPU程序调试/PGG_A.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1183e807c833292a0dd27bf445097